### PR TITLE
Leverage the RSYNC_MODULE_PATH variable provided by rsync

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -261,13 +261,13 @@ pre-xfer exec = '/home/sfs/sfs/php-sync/rsync-check.sh'
     path = /mnt/batches
 ```
 
-Edit `/home/sfs/sfs/php-sync/rsync-check.sh` to use `CHECKFILE="/mnt/data/.sfs.mounted"`. This file is used to check whether the original filesystem is effectively mounted:
+The `/home/sfs/sfs/php-sync/rsync-check.sh` script is used to check whether the filesystems are effectively mounted:
 
 ```
-touch /mnt/data/.sfs.mounted
+touch /mnt/data/.sfs.mounted /mnt/batches/.sfs.mounted
 ```
 
-If the file does not exist, rsync will refuse to transfer any file.
+If these files do not exist, rsync will refuse to transfer any file.
 
 Start rsyncd on each node
 -------------------

--- a/php-sync/rsync-check.sh
+++ b/php-sync/rsync-check.sh
@@ -6,6 +6,4 @@
 
 # Put in rscynd.conf: pre-xfer exec = '/home/www-data/php-sync/rsync-check.sh'
 
-CHECKFILE="/home/www-data/data/.sfs.mounted"
-
-exec test -r "$CHECKFILE"
+exec test -r "${RSYNC_MODULE_PATH}"/.sfs.mounted

--- a/php-sync/rsync-check.sh
+++ b/php-sync/rsync-check.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # For each rsync operation, check whether the destination
 # filesystem is mounted. Otherwise the operation fails

--- a/php-sync/rsync-check.sh
+++ b/php-sync/rsync-check.sh
@@ -8,4 +8,4 @@
 
 CHECKFILE="/home/www-data/data/.sfs.mounted"
 
-exec ls -1 "$CHECKFILE"
+exec test -r "$CHECKFILE"


### PR DESCRIPTION
This avoids the need to modify the rsync-check.sh script. If the check is applied to the batches module then it does require .sfs.mounted to be created there too but this is not such a bad idea.