### PR TITLE
Fix a bug due to the unreleased lock

### DIFF
--- a/fuse/util.c
+++ b/fuse/util.c
@@ -132,6 +132,7 @@ int sfs_begin_access (void) {
 	#ifdef FUSE_28
 	umask (ctx->umask);
 	#endif
+	pthread_mutex_unlock (&(state->access_mutex));
 	return 1;
 	
 error:


### PR DESCRIPTION
Fix a bug due to the unreleased lock in the sfs_begin_access method